### PR TITLE
Check the effect allele of priors and sumstats

### DIFF
--- a/extract_snpvar.py
+++ b/extract_snpvar.py
@@ -80,7 +80,14 @@ if __name__ == '__main__':
     logging.info('Merging sumstats with per-SNP h2 data...')
     t0 = time.time()
     df_meta = df_meta.loc[df_meta.index.isin(df_snps.index)]
+    df_snps = df_snps.rename(columns = {'A1': 'A_eff'})
     df = df_meta.merge(df_snps.drop(columns=SNP_COLUMNS, errors='ignore'), left_index=True, right_index=True)
+    #flip Z-sign if A1 of prior not match A1 of sumstats
+    is_flipped = df['A2'] == df['A_eff']
+    if is_flipped.sum() > 0:
+        df.loc[is_flipped, 'Z'] *= -1
+        logging.info('Flipping the Z-sign of %d SNPs that A1 in sumstats = A2 in the per-SNP h2 data'%(is_flipped.sum()))
+    df = df.drop(columns = 'A_eff')
     logging.info('Done in %0.2f seconds'%(time.time() - t0))
         
     #If we didn't find everything, write a list of missing SNPs to an output file


### PR DESCRIPTION
Hi Omer, 

The mismatch of `A1` between precomputed priors and sumstats won't raise any warning. 

--
1. In detail, as in the wiki 1, 

>PolyFun approach 1: Using precomputed prior causal probabilities based on a meta-analysis of 15 UK Biobank traits
...
It can accept files with any combination of columns, as long as they include the following columns:
...
A1 - The effect allele (i.e., the sign of the effect size is with respect to A1)
...
The script will output a file with exactly the same columns and one additional column called SNPVAR.


It mentioned that `A1` is the effect allele but missed **`A1` in ss must match `A1` of precomputed priors**, the merge function here, 
```py
SNP_COLUMNS = ['CHR', 'SNP', 'BP', 'A1', 'A2']
...
df = df_meta.merge(df_snps.drop(columns=SNP_COLUMNS, errors='ignore'), left_index=True, right_index=True)
```
will always return the modified ss+var, which has `A1` fixed by `df_meta`. Thus could output a file with flipped `A1` `A2` comparing to ss. 

--

2. **If someone didn't see this log when using the precomputed priors, perhaps he had already encountered this issue -- the precomputed priors and UKBB ld are perfectly matched.** 
```py
logging.info('Flipping the effect-sign of %d SNPs that are flipped compared to the LD panel'%(is_flipped.sum()))
```

--

3. This PR adds a checking step when merging ss to prior.

The indexes (contain two allele) are perfectly matched, the flipping can be done easily by comparing `df['A2'] == df['A_eff']`.
```py
    #merge the dfs
...
    df_meta = df_meta.loc[df_meta.index.isin(df_snps.index)]
    df_snps = df_snps.rename(columns = {'A1': 'A_eff'})
    df = df_meta.merge(df_snps.drop(columns=SNP_COLUMNS, errors='ignore'), left_index=True, right_index=True)
    #flip Z-sign if A1 of prior not match A1 of sumstats
    is_flipped = df['A2'] == df['A_eff']
    if is_flipped.sum() > 0:
        df.loc[is_flipped, 'Z'] *= -1
        logging.info('Flipping the Z-sign of %d SNPs that A1 in sumstats = A2 in the per-SNP h2 data'%(is_flipped.sum()))
    df = df.drop(columns = 'A_eff')
...
```

--

BTW, the illustration in wiki was not the real output of `extract_snpvar.py` (no Z), I think it's better to clarify which column comes from prior or ss.

>CHR  BP        SNP                    A1        A2  SNPVAR
1    10000006  rs186077422            G         A   4.0733e-09

>CHR(prior)  BP(prior)        SNP(prior)                    A1(prior)        A2(prior)    Z(ss)  SNPVAR(prior)

Hope this PR could be helpful.

--

Best,
Maomao