### PR TITLE
Enable --allow-swapped-indel-alleles for SuSiE

### DIFF
--- a/finemapper.py
+++ b/finemapper.py
@@ -1196,7 +1196,8 @@ if __name__ == '__main__':
         finemap_obj = SUSIE_Wrapper(genotypes_file=args.geno, sumstats_file=args.sumstats, n=args.n, chr_num=args.chr,
                                     sample_file=args.sample_file, incl_samples=args.incl_samples,
                                     ldstore_exe=args.ldstore2, n_threads=args.threads,
-                                    cache_dir=args.cache_dir, memory=args.memory)
+                                    cache_dir=args.cache_dir, memory=args.memory,
+                                    allow_swapped_indel_alleles=args.allow_swapped_indel_alleles)
     elif args.method == 'finemap':
         if args.susie_outfile is not None:
             raise ValueError('--susie-outfile cannot be specified with finemap method')


### PR DESCRIPTION
This is embarrassing. Since `set_snpid_index()` and `sync_ld_sumstats()` are common to both FINEMAP and SuSiE, I only tested my previous PR with FINEMAP. When I ran it this morning with SuSiE, it didn't work. This is because I forgot to pass `allow_swapped_indel_alleles` to `SUSIE_Wrapper()` :man_facepalming:

xref: #66, #67