### PR TITLE
fix susie allele order

### DIFF
--- a/finemapper.py
+++ b/finemapper.py
@@ -879,6 +879,8 @@ class SUSIE_Wrapper(Fine_Mapping):
         df_susie = self.df_sumstats_locus.copy()
         df_susie['PIP'] = pip
         df_susie['BETA_MEAN'] = beta_mean
+        # flip back the finemap BETA, as the alleles are in original order
+        df_susie.loc[is_flipped, 'BETA_MEAN'] *= (-1)
         df_susie['BETA_SD'] = np.sqrt(beta_var)
         
         #add distance from center


### PR DESCRIPTION
Hi Omer,

Many thanks for your detailed instructions to find the problem.  I located the problem comes from the allele order. I checked the results from FINEMAP do not have problem,  the problem only exists in susie as the finemapper. 

When the susie finemap flip the sign of SNP Z score, it forgets to flip the alleles order.  Thus the alleles are in orginal order, however, the BETA_MEAN is in the flipped order. 

I create a pull request to fix the issue, hope it helps.   

Fixes omerwe/polyfun#80

Regards,
Zhili
 