### PR TITLE
Expose SuSiE arg max_iter as --susie-max-iter

### DIFF
--- a/finemapper.py
+++ b/finemapper.py
@@ -702,7 +702,7 @@ class SUSIE_Wrapper(Fine_Mapping):
 
 
 
-    def finemap(self, locus_start, locus_end, num_causal_snps, use_prior_causal_prob=True, prior_var=None, residual_var=None, residual_var_init=None, hess_resvar=False, hess=False, hess_iter=100, hess_min_h2=None, verbose=False, ld_file=None, debug_dir=None, allow_missing=False, susie_outfile=None, finemap_dir=None):
+    def finemap(self, locus_start, locus_end, num_causal_snps, use_prior_causal_prob=True, prior_var=None, residual_var=None, residual_var_init=None, hess_resvar=False, hess=False, hess_iter=100, hess_min_h2=None, susie_max_iter=100, verbose=False, ld_file=None, debug_dir=None, allow_missing=False, susie_outfile=None, finemap_dir=None):
 
         #check params
         if use_prior_causal_prob and 'SNPVAR' not in self.df_sumstats.columns:
@@ -826,6 +826,7 @@ class SUSIE_Wrapper(Fine_Mapping):
                 # estimate_prior_variance=(prior_var is None),
                 # residual_variance=(self.R_null if (residual_var is None) else residual_var),
                 # estimate_residual_variance=(residual_var is None),
+                # max_iter=susie_max_iter,
                 # verbose=verbose,
                 # prior_weights=(prior_weights.reshape((m,1)) if use_prior_causal_prob else self.R_null)
             # )
@@ -842,6 +843,7 @@ class SUSIE_Wrapper(Fine_Mapping):
                     estimate_prior_variance=(prior_var is None),
                     residual_variance=(self.R_null if (residual_var_init is None) else residual_var_init),
                     estimate_residual_variance=(residual_var is None),
+                    max_iter=susie_max_iter,
                     verbose=verbose,
                     prior_weights=(prior_weights.reshape((m,1)) if use_prior_causal_prob else self.R_null)
                 )
@@ -856,6 +858,7 @@ class SUSIE_Wrapper(Fine_Mapping):
                     estimate_prior_variance=(prior_var is None),
                     residual_variance=(self.R_null if (residual_var is None) else residual_var),
                     estimate_residual_variance=(residual_var is None),
+                    max_iter=susie_max_iter,
                     verbose=verbose,
                     prior_weights=(prior_weights.reshape((m,1)) if use_prior_causal_prob else self.R_null)
                 )
@@ -936,7 +939,7 @@ class FINEMAP_Wrapper(Fine_Mapping):
 
 
 
-    def finemap(self, locus_start, locus_end, num_causal_snps, use_prior_causal_prob=True, prior_var=None, residual_var=None, hess=False, hess_iter=100, hess_min_h2=None, verbose=False, ld_file=None, debug_dir=None, allow_missing=False, susie_outfile=None, residual_var_init=None, hess_resvar=False, finemap_dir=None):
+    def finemap(self, locus_start, locus_end, num_causal_snps, use_prior_causal_prob=True, prior_var=None, residual_var=None, hess=False, hess_iter=100, hess_min_h2=None, susie_max_iter=100, verbose=False, ld_file=None, debug_dir=None, allow_missing=False, susie_outfile=None, residual_var_init=None, hess_resvar=False, finemap_dir=None):
 
         #check params
         if use_prior_causal_prob and 'SNPVAR' not in self.df_sumstats.columns:
@@ -1196,6 +1199,7 @@ if __name__ == '__main__':
     parser.add_argument('--susie-resvar', default=None, type=float, help='If specified, SuSiE will use this value of the residual variance')
     parser.add_argument('--susie-resvar-init', default=None, type=float, help='If specified, SuSiE will use this initial value of the residual variance')
     parser.add_argument('--susie-resvar-hess', default=False, action='store_true', help='If specified, SuSiE will specify the residual variance using the HESS estimate')
+    parser.add_argument('--susie-max-iter', default=100, type=int, help='SuSiE argument max_iter which controls the max number of IBSS iterations to perform (default: 100)')
     
     #check package versions
     check_package_versions()
@@ -1261,7 +1265,8 @@ if __name__ == '__main__':
                  hess=args.hess, hess_iter=args.hess_iter, hess_min_h2=args.hess_min_h2,
                  verbose=args.verbose, ld_file=args.ld, debug_dir=args.debug_dir, allow_missing=args.allow_missing,
                  susie_outfile=args.susie_outfile, finemap_dir=args.finemap_dir,
-                 residual_var=args.susie_resvar, residual_var_init=args.susie_resvar_init, hess_resvar=args.susie_resvar_hess)
+                 residual_var=args.susie_resvar, residual_var_init=args.susie_resvar_init, hess_resvar=args.susie_resvar_hess,
+                 susie_max_iter=args.susie_max_iter)
     logging.info('Writing fine-mapping results to %s'%(args.out))
     df_finemap.sort_values('PIP', ascending=False, inplace=True)
     if args.out.endswith('.parquet'):


### PR DESCRIPTION
I'd like to be able to increase the max number of iterations because I sometimes get warnings that SuSiE failed to converge after the default of 100 iterations.

## Testing

I tested this new flag with the example from `test_polyfun.py`, which takes 5 iterations to converge.

```sh
# New flag has no effect when it is equal to or above the required number of iterations
python finemapper.py \
  --geno example_data/chr1 \
  --sumstats example_data/chr1.finemap_sumstats.txt.gz \
  --n 383290 \
  --chr 1 \
  --start 46000001 \
  --end 49000001 \
  --method susie \
  --max-num-causal 5 \
  --out /tmp/finemap.1.46000001.49000001.gz \
  --threads 1 \
  --verbose \
  --susie-max-iter 5

# Confirmed it is being passed to SuSiE by triggering the warning
python finemapper.py \
  --geno example_data/chr1 \
  --sumstats example_data/chr1.finemap_sumstats.txt.gz \
  --n 383290 \
  --chr 1 \
  --start 46000001 \
  --end 49000001 \
  --method susie \
  --max-num-causal 5 \
  --out /tmp/finemap.1.46000001.49000001.gz \
  --threads 1 \
  --verbose \
  --susie-max-iter 4

[WARNING]  R[write to console]: Warning message:

[WARNING]  R[write to console]: In (function (bhat, shat, R, n, var_y, XtX, Xty, yty, X_colmeans = NA,  :
[WARNING]  R[write to console]:

[WARNING]  R[write to console]:  IBSS algorithm did not converge in 4 iterations!
                  Please check consistency between summary statistics and LD matrix.
                  See https://stephenslab.github.io/susieR/articles/susierss_diagnostic.html

# New flag has no effect on FINEMAP
python finemapper.py \
  --geno example_data/chr1 \
  --sumstats example_data/chr1.finemap_sumstats.txt.gz \
  --n 383290 \
  --chr 1 \
  --start 46000001 \
  --end 49000001 \
  --method finemap \
  --finemap-exe <path-to-finemap-exe> \
  --max-num-causal 5 \
  --out /tmp/finemap.1.46000001.49000001.gz \
  --threads 1 \
  --verbose \
  --susie-max-iter 4
```