### PR TITLE
Update conda environment for Python 3.8

### DIFF
--- a/polyfun.yml
+++ b/polyfun.yml
@@ -1,12 +1,12 @@
 name: polyfun
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - tqdm
   - r-wavethresh
-  - pyarrow
-  - python=3.6
+  - pyarrow>=3.0
+  - python=3.8
   - scikit-learn
   - r-lattice
   - r-ckmeans.1d.dp
@@ -19,7 +19,7 @@ dependencies:
   - rpy2
   - scipy
   - r-devtools
-  - numpy
+  - numpy>=1.20
   - pandas
   - r-expm
   - pandas-plink
@@ -27,4 +27,3 @@ dependencies:
   - r-susier
   - pip:
     - bgen==1.2.10
-


### PR DESCRIPTION
## Background

Update from Python 3.6 to 3.8. This will also update most
of the dependencies since conda packages are built for
specific minor releases. Stopped at 3.8 because
bgen 1.2.10 can't be installed on macOS with Python 3.9

numpy 1.20.0 was a huge release from Jan 2021. It
dropped support for python 3.6. Now that PR #97
has been merged and Python is being updated, it makes
sense to make the transition

https://numpy.org/devdocs/release/1.20.0-notes.html
https://github.com/numpy/numpy/releases/tag/v1.20.0

pyarrow 2.0+ requires aws-sdk-cpp to be pinned to
1.8.186. This has been backported as far back as the 3.0
release of pyarrow, so this is the new minimum

https://github.com/conda-forge/arrow-cpp-feedstock/issues/567
https://github.com/conda-forge/arrow-cpp-feedstock/pull/640

The defaults channel isn't needed to install Python and R
packages on Linux and macOS. conda-forge has everything you
need. Best case scenario the solver takes longer since it
has to update the index for the defaults channel. Worst case
(albeit unlikely) is that a defaults package will sneak in
and bork the environment (defaults and conda-forge use different
compilers and are generally incompatible)

## Testing

### Linux

```sh
mamba env create -n pf38 --file polyfun.yml
conda activate pf38
python test_polyfun.py --finemap-exe <finemap-exe>
```

<details>
<summary>
<code>conda list --export</code>
</summary>

```
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: linux-64
_libgcc_mutex=0.1=conda_forge
_openmp_mutex=4.5=1_gnu
_r-mutex=1.0.1=anacondar_1
abseil-cpp=20210324.2=h9c3ff4c_0
arrow-cpp=7.0.0=py38hdbd6c21_2_cpu
attrs=21.4.0=pyhd8ed1ab_0
aws-c-cal=0.5.11=h95a6274_0
aws-c-common=0.6.2=h7f98852_0
aws-c-event-stream=0.2.7=h3541f99_13
aws-c-io=0.10.5=hfb6a706_0
aws-checksums=0.1.11=ha31a3da_7
aws-sdk-cpp=1.8.186=hb4091e7_3
backports=1.0=py_2
backports.zoneinfo=0.2.1=py38h497a2fe_4
bgen=1.2.10=pypi_0
binutils_impl_linux-64=2.36.1=h193b22a_2
binutils_linux-64=2.36=hf3e587d_8
bitarray=2.4.0=py38h0a891b7_0
bokeh=2.4.2=py38h578d9bd_0
brotli=1.0.9=h7f98852_6
brotli-bin=1.0.9=h7f98852_6
bwidget=1.9.14=ha770c72_1
bzip2=1.0.8=h7f98852_4
c-ares=1.18.1=h7f98852_0
ca-certificates=2021.10.8=ha878542_0
cairo=1.16.0=ha12eb4b_1010
certifi=2021.10.8=py38h578d9bd_1
cffi=1.15.0=py38h3931269_0
click=8.0.4=py38h578d9bd_0
cloudpickle=2.0.0=pyhd8ed1ab_0
colorama=0.4.4=pyh9f0ad1d_0
curl=7.82.0=h7bff187_0
cycler=0.11.0=pyhd8ed1ab_0
cytoolz=0.11.2=py38h497a2fe_1
dask=2022.3.0=pyhd8ed1ab_0
dask-core=2022.3.0=pyhd8ed1ab_0
deprecated=1.2.13=pyh6c4a22f_0
distributed=2022.3.0=pyhd8ed1ab_0
expat=2.4.7=h27087fc_0
font-ttf-dejavu-sans-mono=2.37=hab24e00_0
font-ttf-inconsolata=3.000=h77eed37_0
font-ttf-source-code-pro=2.038=h77eed37_0
font-ttf-ubuntu=0.83=hab24e00_0
fontconfig=2.13.96=h8e229c2_2
fonts-conda-ecosystem=1=0
fonts-conda-forge=1=0
fonttools=4.31.2=py38h0a891b7_0
freetype=2.10.4=h0708190_1
fribidi=1.0.10=h516909a_0
fsspec=2022.2.0=pyhd8ed1ab_0
gcc_impl_linux-64=9.4.0=h03d3576_14
gcc_linux-64=9.4.0=h391b98a_8
gettext=0.19.8.1=h73d1719_1008
gflags=2.2.2=he1b5a44_1004
gfortran_impl_linux-64=9.4.0=h0003116_14
gfortran_linux-64=9.4.0=hf0ab688_8
giflib=5.2.1=h516909a_2
glog=0.5.0=h48cff8f_0
graphite2=1.3.13=he1b5a44_1001
grpc-cpp=1.43.2=h9e046d8_1
gsl=2.7=he838d99_0
gxx_impl_linux-64=9.4.0=h03d3576_14
gxx_linux-64=9.4.0=h0316aca_8
harfbuzz=3.4.0=hb4a5f5f_0
heapdict=1.0.1=py_0
icu=69.1=h9c3ff4c_0
importlib-metadata=4.11.3=py38h578d9bd_0
importlib_metadata=4.11.3=hd8ed1ab_0
iniconfig=1.1.1=pyh9f0ad1d_0
jbig=2.1=h7f98852_2003
jinja2=3.0.3=pyhd8ed1ab_0
joblib=1.1.0=pyhd8ed1ab_0
jpeg=9e=h7f98852_0
kernel-headers_linux-64=2.6.32=he073ed8_15
keyutils=1.6.1=h166bdaf_0
kiwisolver=1.4.0=py38h43d8883_0
krb5=1.19.3=h3790be6_0
lcms2=2.12=hddcbb42_0
ld_impl_linux-64=2.36.1=hea4e1c9_2
lerc=3.0=h9c3ff4c_0
libblas=3.9.0=13_linux64_openblas
libbrotlicommon=1.0.9=h7f98852_6
libbrotlidec=1.0.9=h7f98852_6
libbrotlienc=1.0.9=h7f98852_6
libcblas=3.9.0=13_linux64_openblas
libcrc32c=1.1.2=h9c3ff4c_0
libcurl=7.82.0=h7bff187_0
libdeflate=1.10=h7f98852_0
libedit=3.1.20191231=he28a2e2_2
libev=4.33=h516909a_1
libevent=2.1.10=h9b69904_4
libffi=3.4.2=h7f98852_5
libgcc-devel_linux-64=9.4.0=hd854feb_14
libgcc-ng=11.2.0=h1d223b6_14
libgfortran-ng=11.2.0=h69a702a_14
libgfortran5=11.2.0=h5c6108e_14
libgit2=1.4.2=h6529ace_0
libglib=2.70.2=h174f98d_4
libgomp=11.2.0=h1d223b6_14
libgoogle-cloud=1.35.0=h6945097_2
libiconv=1.16=h516909a_0
liblapack=3.9.0=13_linux64_openblas
libnghttp2=1.47.0=h727a467_0
libnsl=2.0.0=h7f98852_0
libopenblas=0.3.18=pthreads_h8fe5266_0
libpng=1.6.37=hed695b0_2
libprotobuf=3.19.4=h780b84a_0
libsanitizer=9.4.0=h79bfe98_14
libssh2=1.10.0=ha56f1ee_2
libstdcxx-devel_linux-64=9.4.0=hd854feb_14
libstdcxx-ng=11.2.0=he4da1e4_14
libthrift=0.15.0=he6d91bd_1
libtiff=4.3.0=h542a066_3
libutf8proc=2.7.0=h7f98852_0
libuuid=2.32.1=h14c3975_1000
libwebp=1.2.2=h3452ae3_0
libwebp-base=1.2.2=h7f98852_1
libxcb=1.13=h7f98852_1004
libxml2=2.9.12=h885dcf4_1
libzlib=1.2.11=h36c2ea0_1013
locket=0.2.0=py_2
lz4-c=1.9.3=h9c3ff4c_1
make=4.3=hd18ef5c_1
markupsafe=2.1.1=py38h0a891b7_0
matplotlib-base=3.5.1=py38hf4fb855_0
msgpack-python=1.0.3=py38h1fd1430_0
munkres=1.1.4=pyh9f0ad1d_0
ncurses=6.3=h9c3ff4c_0
networkx=2.7.1=pyhd8ed1ab_1
numpy=1.22.3=py38h05e7239_0
openjpeg=2.4.0=hb52868f_1
openssl=1.1.1n=h166bdaf_0
orc=1.7.3=h1be678f_0
packaging=21.3=pyhd8ed1ab_0
pandas=1.4.1=py38h43a58ef_0
pandas-plink=2.2.9=py38h497a2fe_0
pango=1.48.10=h4dcc4a0_3
parquet-cpp=1.5.1=1
partd=1.2.0=pyhd8ed1ab_0
pcre=8.45=h9c3ff4c_0
pcre2=10.37=h032f7d1_0
pillow=9.0.1=py38h0ee0e06_2
pip=22.0.4=pyhd8ed1ab_0
pixman=0.40.0=h36c2ea0_0
pluggy=1.0.0=py38h578d9bd_2
psutil=5.9.0=py38h497a2fe_0
pthread-stubs=0.4=h36c2ea0_1001
py=1.11.0=pyh6c4a22f_0
pyarrow=7.0.0=py38he7e5f7d_2_cpu
pycparser=2.21=pyhd8ed1ab_0
pyparsing=3.0.7=pyhd8ed1ab_0
pytest=7.1.1=py38h578d9bd_0
python=3.8.12=ha38a3c6_3_cpython
python-dateutil=2.8.2=pyhd8ed1ab_0
python-tzdata=2022.1=pyhd8ed1ab_0
python_abi=3.8=2_cp38
pytz=2022.1=pyhd8ed1ab_0
pytz-deprecation-shim=0.1.0.post0=py38h578d9bd_1
pyyaml=6.0=py38h497a2fe_3
r=4.1=r41hd8ed1ab_1004
r-askpass=1.1=r41hcfec24a_2
r-assertthat=0.2.1=r41hc72bb7e_2
r-backports=1.4.1=r41hcfec24a_0
r-base=4.1.2=hde4fec0_0
r-base64enc=0.1_3=r41hcfec24a_1004
r-boot=1.3_28=r41hc72bb7e_0
r-brew=1.0_7=r41hc72bb7e_0
r-brio=1.1.3=r41hcfec24a_0
r-cachem=1.0.6=r41hcfec24a_0
r-callr=3.7.0=r41hc72bb7e_0
r-ckmeans.1d.dp=4.3.4=r41h03ef668_0
r-class=7.3_20=r41hcfec24a_0
r-cli=3.2.0=r41h03ef668_0
r-clipr=0.8.0=r41hc72bb7e_0
r-cluster=2.1.2=r41h859d828_0
r-codetools=0.2_18=r41hc72bb7e_0
r-colorspace=2.0_3=r41h06615bd_0
r-commonmark=1.8.0=r41h06615bd_0
r-covr=3.5.1=r41h03ef668_0
r-cpp11=0.4.2=r41hc72bb7e_0
r-crayon=1.5.0=r41hc72bb7e_0
r-credentials=1.3.2=r41hc72bb7e_0
r-crosstalk=1.2.0=r41hc72bb7e_0
r-curl=4.3.2=r41hcfec24a_0
r-desc=1.4.1=r41hc72bb7e_0
r-devtools=2.4.3=r41hc72bb7e_0
r-diffobj=0.3.5=r41hcfec24a_0
r-digest=0.6.29=r41h03ef668_0
r-dt=0.21=r41hc72bb7e_0
r-ellipsis=0.3.2=r41hcfec24a_0
r-evaluate=0.15=r41hc72bb7e_0
r-expm=0.999_6=r41h52d45c5_0
r-fansi=1.0.3=r41h06615bd_0
r-farver=2.1.0=r41h03ef668_0
r-fastmap=1.1.0=r41h03ef668_0
r-foreign=0.8_82=r41hcfec24a_0
r-fs=1.5.2=r41h03ef668_0
r-gbrd=0.4_11=r41hc72bb7e_1003
r-gert=1.5.0=r41h30f61c7_1
r-ggplot2=3.3.5=r41hc72bb7e_0
r-gh=1.3.0=r41hc72bb7e_0
r-git2r=0.30.1=r41h96773ce_0
r-gitcreds=0.1.1=r41hc72bb7e_0
r-glue=1.6.2=r41h06615bd_0
r-gtable=0.3.0=r41hc72bb7e_3
r-highr=0.9=r41hc72bb7e_0
r-htmltools=0.5.2=r41h03ef668_0
r-htmlwidgets=1.5.4=r41hc72bb7e_0
r-httr=1.4.2=r41hc72bb7e_0
r-ini=0.3.1=r41hc72bb7e_1003
r-irlba=2.3.5=r41he454529_0
r-isoband=0.2.5=r41h03ef668_0
r-jquerylib=0.1.4=r41hc72bb7e_0
r-jsonlite=1.8.0=r41h06615bd_0
r-kernsmooth=2.23_20=r41h742201e_0
r-knitr=1.37=r41hc72bb7e_1
r-labeling=0.4.2=r41hc72bb7e_1
r-later=1.2.0=r41h03ef668_0
r-lattice=0.20_45=r41hcfec24a_0
r-lazyeval=0.2.2=r41hcfec24a_2
r-lifecycle=1.0.1=r41hc72bb7e_0
r-magrittr=2.0.2=r41hcfec24a_0
r-mass=7.3_56=r41h06615bd_0
r-matrix=1.4_1=r41h0154571_0
r-matrixstats=0.61.0=r41hcfec24a_0
r-memoise=2.0.1=r41hc72bb7e_0
r-mgcv=1.8_39=r41h0154571_0
r-mime=0.12=r41hcfec24a_0
r-mixsqp=0.3_43=r41h306847c_1
r-munsell=0.5.0=r41hc72bb7e_1004
r-nlme=3.1_155=r41h859d828_0
r-nnet=7.3_17=r41hcfec24a_0
r-openssl=2.0.0=r41hfaab4ff_0
r-pillar=1.7.0=r41hc72bb7e_0
r-pkgbuild=1.3.1=r41hc72bb7e_0
r-pkgconfig=2.0.3=r41hc72bb7e_1
r-pkgload=1.2.4=r41h03ef668_0
r-plyr=1.8.6=r41h03ef668_1
r-praise=1.0.0=r41hc72bb7e_1005
r-prettyunits=1.1.1=r41hc72bb7e_1
r-processx=3.5.2=r41hcfec24a_0
r-promises=1.2.0.1=r41h03ef668_0
r-ps=1.6.0=r41hcfec24a_0
r-purrr=0.3.4=r41hcfec24a_1
r-r6=2.5.1=r41hc72bb7e_0
r-rappdirs=0.3.3=r41hcfec24a_0
r-rbibutils=2.2.7=r41hcfec24a_0
r-rcmdcheck=1.4.0=r41h785f33e_0
r-rcolorbrewer=1.1_2=r41h785f33e_1003
r-rcpp=1.0.8.3=r41h7525677_0
r-rcpparmadillo=0.10.8.1.0=r41h306847c_0
r-rdpack=2.3=r41hc72bb7e_0
r-recommended=4.1=r41hd8ed1ab_1004
r-rematch2=2.1.2=r41hc72bb7e_1
r-remotes=2.4.2=r41hc72bb7e_0
r-reshape=0.8.8=r41hc72bb7e_3
r-rex=1.2.1=r41hc72bb7e_0
r-rlang=1.0.2=r41h7525677_0
r-roxygen2=7.1.2=r41h03ef668_0
r-rpart=4.1.16=r41hcfec24a_0
r-rprojroot=2.0.2=r41hc72bb7e_0
r-rstudioapi=0.13=r41hc72bb7e_0
r-rversions=2.1.1=r41hc72bb7e_0
r-scales=1.1.1=r41hc72bb7e_0
r-sessioninfo=1.2.2=r41hc72bb7e_0
r-spatial=7.3_15=r41hcfec24a_0
r-stringi=1.7.6=r41h337692f_1
r-stringr=1.4.0=r41hc72bb7e_2
r-survival=3.3_1=r41h06615bd_0
r-susier=0.11.92=r41hc72bb7e_0
r-sys=3.4=r41hcfec24a_0
r-testthat=3.1.2=r41h03ef668_0
r-tibble=3.1.6=r41hcfec24a_0
r-usethis=2.1.5=r41hc72bb7e_0
r-utf8=1.2.2=r41hcfec24a_0
r-vctrs=0.3.8=r41hcfec24a_1
r-viridislite=0.4.0=r41hc72bb7e_0
r-waldo=0.4.0=r41hc72bb7e_0
r-wavethresh=4.6.8=r41hcfec24a_1004
r-whisker=0.4=r41hc72bb7e_1
r-withr=2.5.0=r41hc72bb7e_0
r-xfun=0.30=r41h7525677_0
r-xml2=1.3.3=r41h03ef668_0
r-xopen=1.0.0=r41hc72bb7e_1003
r-yaml=2.3.5=r41h06615bd_0
r-zip=2.2.0=r41hcfec24a_0
re2=2022.02.01=h9c3ff4c_0
readline=8.1=h46c0cb4_0
rpy2=3.4.5=py38r41h6c62de6_3
s2n=1.0.10=h9b69904_0
scikit-learn=1.0.2=py38h1561384_0
scipy=1.8.0=py38h56a6a73_1
sed=4.8=he412f7d_0
setuptools=60.10.0=py38h578d9bd_0
simplegeneric=0.8.1=py_1
six=1.16.0=pyh6c4a22f_0
snappy=1.1.8=he1b5a44_3
sortedcontainers=2.4.0=pyhd8ed1ab_0
sqlite=3.37.1=h4ff8645_0
sysroot_linux-64=2.12=he073ed8_15
tblib=1.7.0=pyhd8ed1ab_0
threadpoolctl=3.1.0=pyh8a188c0_0
tk=8.6.12=h27826a3_0
tktable=2.10=hb7b940f_3
tomli=2.0.1=pyhd8ed1ab_0
toolz=0.11.2=pyhd8ed1ab_0
tornado=6.1=py38h497a2fe_2
tqdm=4.63.1=pyhd8ed1ab_0
typing_extensions=4.1.1=pyha770c72_0
tzdata=2022a=h191b570_0
tzlocal=4.1=py38h578d9bd_1
unicodedata2=14.0.0=py38h497a2fe_0
wheel=0.37.1=pyhd8ed1ab_0
wrapt=1.14.0=py38h0a891b7_0
xarray=2022.3.0=pyhd8ed1ab_0
xorg-kbproto=1.0.7=h14c3975_1002
xorg-libice=1.0.10=h516909a_0
xorg-libsm=1.2.3=hd9c2040_1000
xorg-libx11=1.7.2=h7f98852_0
xorg-libxau=1.0.9=h14c3975_0
xorg-libxdmcp=1.1.3=h516909a_0
xorg-libxext=1.3.4=h7f98852_1
xorg-libxrender=0.9.10=h7f98852_1003
xorg-libxt=1.2.1=h7f98852_2
xorg-renderproto=0.11.1=h14c3975_1002
xorg-xextproto=7.3.0=h14c3975_1002
xorg-xproto=7.0.31=h14c3975_1007
xz=5.2.5=h516909a_1
yaml=0.2.5=h7f98852_2
zict=2.1.0=pyhd8ed1ab_0
zipp=3.7.0=pyhd8ed1ab_1
zlib=1.2.11=h36c2ea0_1013
zstandard=0.17.0=py38h497a2fe_0
zstd=1.5.2=ha95c52a_0
```
</details>

### macOS

```sh
mamba env create -n pf38 --file polyfun.yml
conda activate pf38
python test_polyfun.py
```

<details>
<summary>
<code>conda list --export</code>
</summary>

```
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-64
_r-mutex=1.0.1=anacondar_1
abseil-cpp=20210324.2=he49afe7_0
arrow-cpp=7.0.0=py38h04388a0_2_cpu
attrs=21.4.0=pyhd8ed1ab_0
aws-c-cal=0.5.11=hd2e2f4b_0
aws-c-common=0.6.2=h0d85af4_0
aws-c-event-stream=0.2.7=hb9330a7_13
aws-c-io=0.10.5=h35aa462_0
aws-checksums=0.1.11=h0010a65_7
aws-sdk-cpp=1.8.186=h766a74d_3
backports=1.0=py_2
backports.zoneinfo=0.2.1=py38h96a0964_4
bgen=1.2.10=pypi_0
bitarray=2.4.0=py38hed1de0f_0
bokeh=2.4.2=py38h50d1736_0
brotli=1.0.9=h0d85af4_6
brotli-bin=1.0.9=h0d85af4_6
bwidget=1.9.14=h694c41f_1
bzip2=1.0.8=h0d85af4_4
c-ares=1.18.1=h0d85af4_0
ca-certificates=2021.10.8=h033912b_0
cairo=1.16.0=h9e0e54b_1010
cctools_osx-64=973.0.1=h2b735b3_10
certifi=2021.10.8=py38h50d1736_1
cffi=1.15.0=py38h1a44b6c_0
clang=13.0.1=h694c41f_0
clang-13=13.0.1=default_he082bbe_0
clang_osx-64=13.0.1=h71a8856_0
clangxx=13.0.1=default_he082bbe_0
clangxx_osx-64=13.0.1=heae0f87_0
click=8.0.4=py38h50d1736_0
cloudpickle=2.0.0=pyhd8ed1ab_0
colorama=0.4.4=pyh9f0ad1d_0
compiler-rt=13.0.1=he01351e_0
compiler-rt_osx-64=13.0.1=hd3f61c9_0
curl=7.82.0=h9f20792_0
cycler=0.11.0=pyhd8ed1ab_0
cytoolz=0.11.2=py38h96a0964_1
dask=2022.3.0=pyhd8ed1ab_0
dask-core=2022.3.0=pyhd8ed1ab_0
deprecated=1.2.13=pyh6c4a22f_0
distributed=2022.3.0=pyhd8ed1ab_0
expat=2.4.7=h96cf925_0
font-ttf-dejavu-sans-mono=2.37=hab24e00_0
font-ttf-inconsolata=3.000=h77eed37_0
font-ttf-source-code-pro=2.038=h77eed37_0
font-ttf-ubuntu=0.83=hab24e00_0
fontconfig=2.13.96=h676cef8_2
fonts-conda-ecosystem=1=0
fonts-conda-forge=1=0
fonttools=4.31.2=py38hed1de0f_0
freetype=2.10.4=h4cff582_1
fribidi=1.0.10=hbcb3906_0
fsspec=2022.2.0=pyhd8ed1ab_0
gettext=0.19.8.1=hd1a6beb_1008
gflags=2.2.2=hb1e8313_1004
gfortran_impl_osx-64=9.3.0=h9cc0e5e_23
gfortran_osx-64=9.3.0=h18f7dce_15
giflib=5.2.1=hbcb3906_2
glog=0.5.0=h25b26a9_0
gmp=6.2.1=h2e338ed_0
graphite2=1.3.13=h2e338ed_1001
grpc-cpp=1.43.2=hb6405b5_1
gsl=2.7=h93259b0_0
harfbuzz=4.1.0=h48644e2_0
heapdict=1.0.1=py_0
icu=69.1=he49afe7_0
importlib-metadata=4.11.3=py38h50d1736_0
importlib_metadata=4.11.3=hd8ed1ab_0
iniconfig=1.1.1=pyh9f0ad1d_0
isl=0.22.1=hb1e8313_2
jbig=2.1=h0d85af4_2003
jinja2=3.0.3=pyhd8ed1ab_0
joblib=1.1.0=pyhd8ed1ab_0
jpeg=9e=h0d85af4_0
kiwisolver=1.4.0=py38h8b7791e_0
krb5=1.19.3=hb49756b_0
lcms2=2.12=h577c468_0
ld64_osx-64=609=hd77a64a_10
lerc=3.0=he49afe7_0
libblas=3.9.0=13_osx64_openblas
libbrotlicommon=1.0.9=h0d85af4_6
libbrotlidec=1.0.9=h0d85af4_6
libbrotlienc=1.0.9=h0d85af4_6
libcblas=3.9.0=13_osx64_openblas
libclang-cpp13=13.0.1=default_he082bbe_0
libcrc32c=1.1.2=he49afe7_0
libcurl=7.82.0=h9f20792_0
libcxx=13.0.1=hc203e6f_0
libdeflate=1.10=h0d85af4_0
libedit=3.1.20191231=h0678c8f_2
libev=4.33=haf1e3a3_1
libevent=2.1.10=h815e4d9_4
libffi=3.4.2=h0d85af4_5
libgfortran=5.0.0=9_3_0_h6c81a4c_23
libgfortran-devel_osx-64=9.3.0=h6c81a4c_23
libgfortran5=9.3.0=h6c81a4c_23
libgit2=1.4.2=h514b3f4_0
libglib=2.70.2=hf1fb8c0_4
libgoogle-cloud=1.35.0=h52a585b_2
libiconv=1.16=haf1e3a3_0
liblapack=3.9.0=13_osx64_openblas
libllvm13=13.0.1=h64f94b2_2
libnghttp2=1.47.0=h942079c_0
libopenblas=0.3.18=openmp_h3351f45_0
libpng=1.6.37=h7cec526_2
libprotobuf=3.19.4=hcf210ce_0
libssh2=1.10.0=h52ee1ee_2
libthrift=0.15.0=hab56fdc_1
libtiff=4.3.0=h17f2ce3_3
libutf8proc=2.7.0=h0d85af4_0
libwebp=1.2.2=h28dabe5_0
libwebp-base=1.2.2=h0d85af4_1
libxcb=1.13=h0d85af4_1004
libxml2=2.9.12=h7e28ab6_1
libzlib=1.2.11=h9173be1_1013
llvm-openmp=13.0.1=hcb1a161_1
llvm-tools=13.0.1=h64f94b2_2
locket=0.2.0=py_2
lz4-c=1.9.3=he49afe7_1
make=4.3=h22f3db7_1
markupsafe=2.1.1=py38hed1de0f_0
matplotlib-base=3.5.1=py38hc7d2367_0
mpc=1.2.1=hbb51d92_0
mpfr=4.1.0=h0f52abe_1
msgpack-python=1.0.3=py38h12bbefe_0
munkres=1.1.4=pyh9f0ad1d_0
ncurses=6.2=h2e338ed_4
networkx=2.7.1=pyhd8ed1ab_1
numpy=1.22.3=py38hd52c74b_0
openjpeg=2.4.0=h6e7aa92_1
openssl=1.1.1n=h6c3fc93_0
orc=1.7.3=h84518c8_0
packaging=21.3=pyhd8ed1ab_0
pandas=1.4.1=py38ha53d530_0
pandas-plink=2.2.9=py38h96a0964_0
pango=1.50.6=hc4a7b6d_0
parquet-cpp=1.5.1=2
partd=1.2.0=pyhd8ed1ab_0
pcre=8.45=he49afe7_0
pcre2=10.37=ha16e1b2_0
pillow=9.0.1=py38h7207f37_2
pip=22.0.4=pyhd8ed1ab_0
pixman=0.40.0=hbcb3906_0
pluggy=1.0.0=py38h50d1736_2
psutil=5.9.0=py38h96a0964_0
pthread-stubs=0.4=hc929b4f_1001
py=1.11.0=pyh6c4a22f_0
pyarrow=7.0.0=py38h2688f9d_2_cpu
pycparser=2.21=pyhd8ed1ab_0
pyparsing=3.0.7=pyhd8ed1ab_0
pytest=7.1.1=py38h50d1736_0
python=3.8.12=h17280f6_3_cpython
python-dateutil=2.8.2=pyhd8ed1ab_0
python-tzdata=2022.1=pyhd8ed1ab_0
python_abi=3.8=2_cp38
pytz=2022.1=pyhd8ed1ab_0
pytz-deprecation-shim=0.1.0.post0=py38h50d1736_1
pyyaml=6.0=py38h96a0964_3
r=4.1=r41hd8ed1ab_1004
r-askpass=1.1=r41h28b5c78_2
r-assertthat=0.2.1=r41hc72bb7e_2
r-backports=1.4.1=r41h28b5c78_0
r-base=4.1.2=hbd3716f_1
r-base64enc=0.1_3=r41h28b5c78_1004
r-boot=1.3_28=r41hc72bb7e_0
r-brew=1.0_7=r41hc72bb7e_0
r-brio=1.1.3=r41h28b5c78_0
r-cachem=1.0.6=r41h28b5c78_0
r-callr=3.7.0=r41hc72bb7e_0
r-ckmeans.1d.dp=4.3.4=r41h9951f98_0
r-class=7.3_20=r41h28b5c78_0
r-cli=3.2.0=r41h9951f98_0
r-clipr=0.8.0=r41hc72bb7e_0
r-cluster=2.1.2=r41h749f5a1_0
r-codetools=0.2_18=r41hc72bb7e_0
r-colorspace=2.0_3=r41h0f1d5c4_0
r-commonmark=1.8.0=r41h0f1d5c4_0
r-covr=3.5.1=r41h9951f98_0
r-cpp11=0.4.2=r41hc72bb7e_0
r-crayon=1.5.0=r41hc72bb7e_0
r-credentials=1.3.2=r41hc72bb7e_0
r-crosstalk=1.2.0=r41hc72bb7e_0
r-curl=4.3.2=r41h28b5c78_0
r-desc=1.4.1=r41hc72bb7e_0
r-devtools=2.4.3=r41hc72bb7e_0
r-diffobj=0.3.5=r41h28b5c78_0
r-digest=0.6.29=r41h9951f98_0
r-dt=0.21=r41hc72bb7e_0
r-ellipsis=0.3.2=r41h28b5c78_0
r-evaluate=0.15=r41hc72bb7e_0
r-expm=0.999_6=r41h30cbcce_0
r-fansi=1.0.3=r41h0f1d5c4_0
r-farver=2.1.0=r41h9951f98_0
r-fastmap=1.1.0=r41h9951f98_0
r-foreign=0.8_82=r41h28b5c78_0
r-fs=1.5.2=r41h9951f98_0
r-gbrd=0.4_11=r41hc72bb7e_1003
r-gert=1.5.0=r41ha1c6f2d_1
r-ggplot2=3.3.5=r41hc72bb7e_0
r-gh=1.3.0=r41hc72bb7e_0
r-git2r=0.30.1=r41he6f0618_0
r-gitcreds=0.1.1=r41hc72bb7e_0
r-glue=1.6.2=r41h0f1d5c4_0
r-gtable=0.3.0=r41hc72bb7e_3
r-highr=0.9=r41hc72bb7e_0
r-htmltools=0.5.2=r41h9951f98_0
r-htmlwidgets=1.5.4=r41hc72bb7e_0
r-httr=1.4.2=r41hc72bb7e_0
r-ini=0.3.1=r41hc72bb7e_1003
r-irlba=2.3.5=r41hc2c5f09_0
r-isoband=0.2.5=r41h9951f98_0
r-jquerylib=0.1.4=r41hc72bb7e_0
r-jsonlite=1.8.0=r41h0f1d5c4_0
r-kernsmooth=2.23_20=r41he19034d_0
r-knitr=1.37=r41hc72bb7e_1
r-labeling=0.4.2=r41hc72bb7e_1
r-later=1.2.0=r41h9951f98_0
r-lattice=0.20_45=r41h28b5c78_0
r-lazyeval=0.2.2=r41h28b5c78_2
r-lifecycle=1.0.1=r41hc72bb7e_0
r-magrittr=2.0.2=r41h28b5c78_0
r-mass=7.3_56=r41h0f1d5c4_0
r-matrix=1.4_1=r41ha2825d1_0
r-matrixstats=0.61.0=r41h28b5c78_0
r-memoise=2.0.1=r41hc72bb7e_0
r-mgcv=1.8_39=r41h60b693f_0
r-mime=0.12=r41h28b5c78_0
r-mixsqp=0.3_43=r41he5a6823_1
r-munsell=0.5.0=r41hc72bb7e_1004
r-nlme=3.1_155=r41h749f5a1_0
r-nnet=7.3_17=r41h28b5c78_0
r-openssl=2.0.0=r41hc6995ed_0
r-pillar=1.7.0=r41hc72bb7e_0
r-pkgbuild=1.3.1=r41hc72bb7e_0
r-pkgconfig=2.0.3=r41hc72bb7e_1
r-pkgload=1.2.4=r41h9951f98_0
r-plyr=1.8.6=r41h9951f98_1
r-praise=1.0.0=r41hc72bb7e_1005
r-prettyunits=1.1.1=r41hc72bb7e_1
r-processx=3.5.2=r41h28b5c78_0
r-promises=1.2.0.1=r41h9951f98_0
r-ps=1.6.0=r41h28b5c78_0
r-purrr=0.3.4=r41h28b5c78_1
r-r6=2.5.1=r41hc72bb7e_0
r-rappdirs=0.3.3=r41h28b5c78_0
r-rbibutils=2.2.7=r41h28b5c78_0
r-rcmdcheck=1.4.0=r41h785f33e_0
r-rcolorbrewer=1.1_2=r41h785f33e_1003
r-rcpp=1.0.8.3=r41hc4bb905_0
r-rcpparmadillo=0.10.8.1.0=r41h7190c71_0
r-rdpack=2.3=r41hc72bb7e_0
r-recommended=4.1=r41hd8ed1ab_1004
r-rematch2=2.1.2=r41hc72bb7e_1
r-remotes=2.4.2=r41hc72bb7e_0
r-reshape=0.8.8=r41hbe3e9c8_3
r-rex=1.2.1=r41hc72bb7e_0
r-rlang=1.0.2=r41hc4bb905_0
r-roxygen2=7.1.2=r41h9951f98_0
r-rpart=4.1.16=r41h28b5c78_0
r-rprojroot=2.0.2=r41hc72bb7e_0
r-rstudioapi=0.13=r41hc72bb7e_0
r-rversions=2.1.1=r41hc72bb7e_0
r-scales=1.1.1=r41hc72bb7e_0
r-sessioninfo=1.2.2=r41hc72bb7e_0
r-spatial=7.3_15=r41h28b5c78_0
r-stringi=1.7.6=r41h99ba7f4_1
r-stringr=1.4.0=r41hc72bb7e_2
r-survival=3.3_1=r41h0f1d5c4_0
r-susier=0.11.92=r41hc72bb7e_0
r-sys=3.4=r41h28b5c78_0
r-testthat=3.1.2=r41h9951f98_0
r-tibble=3.1.6=r41h28b5c78_0
r-usethis=2.1.5=r41hc72bb7e_0
r-utf8=1.2.2=r41h28b5c78_0
r-vctrs=0.3.8=r41h28b5c78_1
r-viridislite=0.4.0=r41hc72bb7e_0
r-waldo=0.4.0=r41hc72bb7e_0
r-wavethresh=4.6.8=r41h28b5c78_1004
r-whisker=0.4=r41hc72bb7e_1
r-withr=2.5.0=r41hc72bb7e_0
r-xfun=0.30=r41hc4bb905_0
r-xml2=1.3.3=r41h9951f98_0
r-xopen=1.0.0=r41hc72bb7e_1003
r-yaml=2.3.5=r41h0f1d5c4_0
r-zip=2.2.0=r41h28b5c78_0
re2=2022.02.01=he49afe7_0
readline=8.1=h05e3726_0
rpy2=3.4.5=py38r41hbe852b5_3
scikit-learn=1.0.2=py38h37f3bb3_0
scipy=1.8.0=py38hd329d04_1
setuptools=60.10.0=py38h50d1736_0
sigtool=0.1.3=h57ddcff_0
simplegeneric=0.8.1=py_1
six=1.16.0=pyh6c4a22f_0
snappy=1.1.8=hb1e8313_3
sortedcontainers=2.4.0=pyhd8ed1ab_0
sqlite=3.37.0=h23a322b_0
tapi=1100.0.11=h9ce4665_0
tblib=1.7.0=pyhd8ed1ab_0
threadpoolctl=3.1.0=pyh8a188c0_0
tk=8.6.12=h5dbffcc_0
tktable=2.10=h49f0cf7_3
tomli=2.0.1=pyhd8ed1ab_0
toolz=0.11.2=pyhd8ed1ab_0
tornado=6.1=py38h96a0964_2
tqdm=4.63.1=pyhd8ed1ab_0
typing_extensions=4.1.1=pyha770c72_0
tzdata=2022a=h191b570_0
tzlocal=4.1=py38h50d1736_1
unicodedata2=14.0.0=py38h96a0964_0
wheel=0.37.1=pyhd8ed1ab_0
wrapt=1.14.0=py38hed1de0f_0
xarray=2022.3.0=pyhd8ed1ab_0
xorg-libxau=1.0.9=h35c211d_0
xorg-libxdmcp=1.1.3=h35c211d_0
xz=5.2.5=haf1e3a3_1
yaml=0.2.5=h0d85af4_2
zict=2.1.0=pyhd8ed1ab_0
zipp=3.7.0=pyhd8ed1ab_1
zlib=1.2.11=h9173be1_1013
zstandard=0.17.0=py38h96a0964_0
zstd=1.5.2=h582d3a0_0
```
</details>