### PR TITLE
Loosen rpy2 pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ PolyFun and PolyLoc are designed for Python >=3.6 and require the following free
 
 It is recommended (but not required) to also install the following:
 * [rpy2](https://rpy2.bitbucket.io/)  (a Python package)
-<br>⚠️ You must use rpy2 version <3.5.7 because newer versions break backwards compatability (see [#149](../../issues/149))
 * [R version 3.5.1 or higher](https://www.r-project.org/)
 * [Ckmeans.1d.dp](https://cran.r-project.org/web/packages/Ckmeans.1d.dp/index.html) (a package for R, that will be invoked from python via the rpy2 package).
 

--- a/finemapper.py
+++ b/finemapper.py
@@ -21,6 +21,7 @@ from sklearn.impute import SimpleImputer
 from polyfun import configure_logger, check_package_versions
 import urllib.request
 from urllib.parse import urlparse
+from packaging.version import Version
 
 
 def splash_screen():
@@ -865,7 +866,7 @@ class SUSIE_Wrapper(Fine_Mapping):
             raise NotImplementedError('Only susie_suff_stat() and susie_bhat() are supported. Check your version of susieR')
         susie_time = time.time()-t0        
         logging.info('Done in %0.2f seconds'%(susie_time))
-        
+
         #extract pip and beta_mean
         pip = np.array(self.susieR.susie_get_pip(susie_obj))
         beta_mean = np.array(self.susieR.coef_susie(susie_obj)[1:])
@@ -894,7 +895,13 @@ class SUSIE_Wrapper(Fine_Mapping):
         df_susie['DISTANCE_FROM_CENTER'] = np.abs(df_susie['BP'] - middle)        
         
         #mark causal sets
-        self.susie_dict = {key:np.array(susie_obj.rx2(key), dtype=object) for key in list(susie_obj.names)}
+        import rpy2
+        logging.info('Using rpy2 version %s'%(rpy2.__version__))
+        if Version(rpy2.__version__) >= Version('3.5.9'):
+            snames = (susie_obj.names).tolist()
+            self.susie_dict = {key: np.array(susie_obj.rx2(key), dtype=object) for key in snames}
+        else:
+            self.susie_dict = {key:np.array(susie_obj.rx2(key), dtype=object) for key in list(susie_obj.names)}
         df_susie['CREDIBLE_SET'] = 0
         susie_sets = self.susie_dict['sets'][0]
         #if type(susie_sets) != self.RNULLType:

--- a/polyfun.yml
+++ b/polyfun.yml
@@ -16,7 +16,7 @@ dependencies:
   - r
   - r-matrixstats
   - networkx
-  - rpy2<3.5.7
+  - rpy2<3.5.7|>=3.5.9
   - scipy
   - r-devtools
   - numpy>=1.20
@@ -25,5 +25,6 @@ dependencies:
   - pandas-plink
   - pip
   - r-susier==0.11.92
+  - packaging
   - pip:
     - bgen==1.2.10


### PR DESCRIPTION
This is a follow up to PR #149. I updated `finemapper.py` to use the existing rpy2 code if rpy2 <3.5.9, and to use the solution from @Ojami in https://github.com/omerwe/polyfun/pull/149#issuecomment-1484110637 if rpy2 >=3.5.9.

As a precaution to avoid the potential missing value bug in rpy2 3.5.7 and 3.5.8, I updated the `polyfun.yml` file to avoid these 2 versions. However, since I don't actually have any evidence that the bug will affect the polyfun code, I didn't explicitly throw an error in `finemapper.py` if one of those versions is installed. In other words, I'm directing users away from these versions, but not preventing a user if they for some reason really want to install one of those versions.

I compare the version strings using the 3rd party package [packaging](https://packaging.pypa.io/en/stable/version.html). This package is maintained by the PyPA, is a dependency of setuptools, and was already installed in the existing polyfun env. Thus I added it to `polyfun.yml` for documentation purposes, but `polyfun.yml.lock` doesn't need to be updated.

xref: #153 