### PR TITLE
Fix `assert df_snp.shape[0]==1` error in compute_ld_bgen

### DIFF
--- a/finemapper.py
+++ b/finemapper.py
@@ -420,7 +420,7 @@ class Fine_Mapping(object):
             snp_chrom = rsid.chrom
             snp_pos = rsid.pos
             assert len(snp_alleles) == 2, 'cannot handle SNPs with more than two alleles'
-            df_snp = df_z.query('SNP == "%s"'%(rsid))
+            df_snp = df_z.query('SNP == "%s"'%(rsid.rsid))
             assert df_snp.shape[0]==1
             a1, a2 = df_snp['A1'].iloc[0], df_snp['A2'].iloc[0]
             snp_a1, snp_a2 = snp_alleles[0], snp_alleles[1]
@@ -428,8 +428,8 @@ class Fine_Mapping(object):
                 raise ValueError('The alleles for SNP %s are different in the sumstats and in the bgen file:\n \
                                  bgen:     A1=%s  A2=%s\n \
                                  sumstats: A1=%s  A2=%s \
-                                '%(rsid, snp_alleles[0], snp_alleles[1], a1, a2))
-            d = {'SNP':rsid, 'CHR':snp_chrom, 'BP':snp_pos, 'A1':snp_a1, 'A2':snp_a2}
+                                '%(rsid.rsid, snp_alleles[0], snp_alleles[1], a1, a2))
+            d = {'SNP':rsid.rsid, 'CHR':snp_chrom, 'BP':snp_pos, 'A1':snp_a1, 'A2':snp_a2}
             list_bgen.append(d)
         df_bgen = pd.DataFrame(list_bgen)
         df_bgen = set_snpid_index(df_bgen, allow_swapped_indel_alleles=self.allow_swapped_indel_alleles)


### PR DESCRIPTION
Due to `rsid` change in #121, `df_z.query` should be queried against `rsid.rsid`, not `rsid`.